### PR TITLE
Fix Linux installation by using conditional ollama dependencies

### DIFF
--- a/Casks/dewey.rb
+++ b/Casks/dewey.rb
@@ -31,9 +31,12 @@ cask "dewey" do
   livecheck do
     skip "Auto-generated on release."
   end
-  depends_on cask: [
-      "ollama-app",
-    ]
+
+  if OS.mac?
+    depends_on cask: "ollama-app"
+  else
+    depends_on formula: "ollama"
+  end
 
   binary "dewey"
 


### PR DESCRIPTION
## Overview

Installing `dewey` or `unbound-force` on Linux fails with:
  Error: macOS is required for this software.
  ==> Installing dependencies: ollama-app, dewey

  This is because `dewey.rb` has a hard dependency on the macOS-only `ollama-app` cask, even though dewey itself has Linux binaries
  available.

  ## Solution
  Use OS-conditional dependencies in `dewey.rb`:
  - **macOS**: depends on `ollama-app` cask (GUI application)
  - **Linux**: depends on `ollama` formula (CLI tool)

  ## Testing
  Successfully tested on Fedora 43 with Homebrew 5.1.3:
  - ✅ `ollama` formula installs correctly
  - ✅ `dewey` cask installs without errors
  - ✅ `unbound-force` cask installs with full dependency chain
  - ✅ All binaries functional